### PR TITLE
bugfix/end_index_incorrect_after_the_first_half_move

### DIFF
--- a/Sources/ChessKit/MoveTree/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree.swift
@@ -56,6 +56,10 @@ public struct MoveTree: Hashable, Sendable {
       self.root = newNode
 
       dictionary = [index: newNode]
+        
+      if index.variation == Index.mainVariation {
+        lastMainVariationIndex = index
+      }
       return index
     }
 


### PR DESCRIPTION
 updated lastMainVariationIndex in guard else clause.